### PR TITLE
Fix podspec

### DIFF
--- a/Example/scripts/cocoapods/originate_theme.rb
+++ b/Example/scripts/cocoapods/originate_theme.rb
@@ -38,26 +38,21 @@ def add_originatetheme_build_phase(project:)
   target            = project.targets.find { |t| t.name == 'OriginateTheme' }
   build_script_name = '[OriginateTheme] Generate Theme Files'
   build_script      = '"${PODS_ROOT}/OriginateTheme/OriginateTheme/Scripts/ot_generator.py" -i "${OTTHEME}" -o "${PODS_ROOT}/OriginateTheme/OriginateTheme/Sources/Classes/"'
-  installed         = target.shell_script_build_phases.any? { |s| s.name == build_script_name }
 
-  if !installed
-    # create build phase
-    build_phase = begin
-      phase = project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
-      phase.name = build_script_name
-      phase.shell_script = build_script
-      phase
-    end
-
-    # insert build phase before "Compile Sources" (otherwise, we could simply use `new_shell_script_build_phase`)
-    compile_phase_index = target.build_phases.index { |p| p.class == Xcodeproj::Project::Object::PBXSourcesBuildPhase } || 0
-    target.build_phases.insert(compile_phase_index, build_phase)
-
-    # save changes
-    project.save()
-
-    puts "[OriginateTheme] Added generator script as Build Phase of '#{target.name}' target."
-  else
-    puts "[OriginateTheme] Generator script is already installed as Build Phase of '#{target.name}' target."
+  # create build phase
+  build_phase = begin
+    phase = project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
+    phase.name = build_script_name
+    phase.shell_script = build_script
+    phase
   end
+
+  # insert build phase before "Compile Sources" (otherwise, we could simply use `new_shell_script_build_phase`)
+  compile_phase_index = target.build_phases.index { |p| p.class == Xcodeproj::Project::Object::PBXSourcesBuildPhase } || 0
+  target.build_phases.insert(compile_phase_index, build_phase)
+
+  # save changes
+  project.save()
+
+  puts "[OriginateTheme] Added generator script as Build Phase of '#{target.name}' target."
 end

--- a/Example/scripts/cocoapods/originate_theme.rb
+++ b/Example/scripts/cocoapods/originate_theme.rb
@@ -36,9 +36,9 @@ end
 
 def add_originatetheme_build_phase(project:)
   target            = project.targets.find { |t| t.name == 'OriginateTheme' }
-  installed         = target.shell_script_build_phases.any? { |s| s.name == build_script_name }
   build_script_name = '[OriginateTheme] Generate Theme Files'
   build_script      = '"${PODS_ROOT}/OriginateTheme/OriginateTheme/Scripts/ot_generator.py" -i "${OTTHEME}" -o "${PODS_ROOT}/OriginateTheme/OriginateTheme/Sources/Classes/"'
+  installed         = target.shell_script_build_phases.any? { |s| s.name == build_script_name }
 
   if !installed
     # create build phase

--- a/OriginateTheme.podspec
+++ b/OriginateTheme.podspec
@@ -13,4 +13,5 @@ Pod::Spec.new do |s|
   s.requires_arc        = true
   s.source_files        = 'OriginateTheme/Sources/**/*'
   s.public_header_files = 'OriginateTheme/Sources/**/*.h'
+  s.resources           = ['OriginateTheme/Scripts/ot_generator.py']
 end

--- a/OriginateTheme/Scripts/originate_theme.rb
+++ b/OriginateTheme/Scripts/originate_theme.rb
@@ -38,26 +38,21 @@ def add_originatetheme_build_phase(project:)
   target            = project.targets.find { |t| t.name == 'OriginateTheme' }
   build_script_name = '[OriginateTheme] Generate Theme Files'
   build_script      = '"${PODS_ROOT}/OriginateTheme/OriginateTheme/Scripts/ot_generator.py" -i "${OTTHEME}" -o "${PODS_ROOT}/OriginateTheme/OriginateTheme/Sources/Classes/"'
-  installed         = target.shell_script_build_phases.any? { |s| s.name == build_script_name }
 
-  if !installed
-    # create build phase
-    build_phase = begin
-      phase = project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
-      phase.name = build_script_name
-      phase.shell_script = build_script
-      phase
-    end
-
-    # insert build phase before "Compile Sources" (otherwise, we could simply use `new_shell_script_build_phase`)
-    compile_phase_index = target.build_phases.index { |p| p.class == Xcodeproj::Project::Object::PBXSourcesBuildPhase } || 0
-    target.build_phases.insert(compile_phase_index, build_phase)
-
-    # save changes
-    project.save()
-
-    puts "[OriginateTheme] Added generator script as Build Phase of '#{target.name}' target."
-  else
-    puts "[OriginateTheme] Generator script is already installed as Build Phase of '#{target.name}' target."
+  # create build phase
+  build_phase = begin
+    phase = project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
+    phase.name = build_script_name
+    phase.shell_script = build_script
+    phase
   end
+
+  # insert build phase before "Compile Sources" (otherwise, we could simply use `new_shell_script_build_phase`)
+  compile_phase_index = target.build_phases.index { |p| p.class == Xcodeproj::Project::Object::PBXSourcesBuildPhase } || 0
+  target.build_phases.insert(compile_phase_index, build_phase)
+
+  # save changes
+  project.save()
+
+  puts "[OriginateTheme] Added generator script as Build Phase of '#{target.name}' target."
 end

--- a/OriginateTheme/Scripts/originate_theme.rb
+++ b/OriginateTheme/Scripts/originate_theme.rb
@@ -36,9 +36,9 @@ end
 
 def add_originatetheme_build_phase(project:)
   target            = project.targets.find { |t| t.name == 'OriginateTheme' }
-  installed         = target.shell_script_build_phases.any? { |s| s.name == build_script_name }
   build_script_name = '[OriginateTheme] Generate Theme Files'
   build_script      = '"${PODS_ROOT}/OriginateTheme/OriginateTheme/Scripts/ot_generator.py" -i "${OTTHEME}" -o "${PODS_ROOT}/OriginateTheme/OriginateTheme/Sources/Classes/"'
+  installed         = target.shell_script_build_phases.any? { |s| s.name == build_script_name }
 
   if !installed
     # create build phase


### PR DESCRIPTION
@pkluz 

PR #17 removed scripts (i.e. the python files) from `source_files` so that Xcode doesn't emit *warning: no rule to process file*. However,`ot_generator.py` is still needed, so this PR adds that back in the podspec via `s.resources`. 

Also, simplified `originate_theme.rb` a bit. The check for previous installations is redundant, as the target of interest resides in the Pods project, which is created from scratch upon each invocation of `pod install`.  Therefore, any project changes made will be wiped away with `pod install`.